### PR TITLE
create default app_service based on first service

### DIFF
--- a/services/blackfire/builder.js
+++ b/services/blackfire/builder.js
@@ -22,6 +22,11 @@ module.exports = {
     parent: '_service',
     builder: (parent, config) => class LandoBlackfire extends parent {
         constructor(id, options = {}) {
+            // set a default app_service using the first service in options._app.info
+            if (options._app.hasOwnProperty('info') && options._app.info instanceof Array) {
+            	const closestService = _.first(options._app.info);
+            	config.app_service = closestService.service;            
+            }
             options = _.merge({}, config, options);
 
             // Ensure that the credentials are correctly set.


### PR DESCRIPTION
If available, uses the first service in `options._app.info` which is typically the primary service, to use as the default `app_service` but if not available, retains the previous `appserver` value. Also still allows for the value to be overridden from the lando.yaml file. 

Closes #3 