### PR TITLE
fix(plugin-system): Make the plugin compatible with the lando 3.21.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,11 @@ services, assert responses, and extract data from HTML/XML/JSON responses.
 
 ## Installation
 
-- [Download and extract the archive of the latest version](https://github.com/blackfireio/lando-plugin/releases);
-- Move the extracted `blackfire` folder to the Lando plugins folder:
+- Install the plugin with the lando cli:
 
 ```bash
-mv blackfire ~/.lando/plugins/
+lando plugin-add https://github.com/blackfireio/lando-plugin.git
 ```
-
-> If the `plugins` directory doesn't exist, create it:
-> ```bash
-> mkdir -p ~/.lando/plugins
-> ```
 
 ## Configuration
 
@@ -101,8 +95,9 @@ services:
 
 ## Known Limitations
 
-- It only works with Debian-based application containers, which is the case for
-  most Lando recipes;
-- The probe is automatically installed in PHP application services. For Python,
-  you need to install the PIP package and use `blackfire-python` instead of
-  `python`.
+- It only works with application containers, which have curl, tar and bash installed.
+- The probe is automatically installed in PHP application services (type: php*).
+  - For custom php services add `app_service_is_php: true` to your blackfire service config
+  - For Python,
+    you need to install the PIP package and use `blackfire-python` instead of
+    `python`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,12 @@
 {
-  "name": "lando-plugin",
+  "name": "@blackfireio/blackfire-lando-plugin",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "@blackfireio/blackfire-lando-plugin",
+      "version": "1.0.4",
       "dependencies": {
         "lodash": "^4.17.21"
       }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,15 @@
 {
+  "name": "@blackfireio/blackfire-lando-plugin",
+  "version": "1.0.4",
+  "author": "blackfire.io",
+  "keywords": [
+    "lando",
+    "lando-plugin",
+    "blackfire"
+  ],
+  "lando": {
+    "legacy": true
+  },
   "dependencies": {
     "lodash": "^4.17.21"
   }

--- a/scripts/install-blackfire-cli.sh
+++ b/scripts/install-blackfire-cli.sh
@@ -5,7 +5,7 @@ if [[ ! -e /usr/local/bin/blackfire ]]; then
   echo "Installing the latest version of Blackfire CLI"
   cd /tmp
   ARCHITECTURE=$(uname -m)
-  wget -nv -O blackfire.tar.gz -L "https://blackfire.io/api/v1/releases/cli/linux/$ARCHITECTURE"
+  curl -LsS "https://blackfire.io/api/v1/releases/cli/linux/$ARCHITECTURE" -o blackfire.tar.gz
   tar -xzf blackfire.tar.gz
   chmod +x blackfire
   cp blackfire /usr/local/bin/blackfire

--- a/scripts/install-blackfire-probe.sh
+++ b/scripts/install-blackfire-probe.sh
@@ -9,7 +9,7 @@ EXTENSION_DIR=$(php -i | grep "^extension_dir =>" | sed -nE "s/extension_dir => 
 
 ARCHITECTURE=$(uname -m)
 echo "Installing Blackfire Probe for PHP ($ARCHITECTURE)"
-(cd /tmp && wget -nv -N "https://blackfire.io/api/v1/releases/probe/php/linux/$ARCHITECTURE/$PHP_VERSION")
+(cd /tmp && curl -LsS "https://blackfire.io/api/v1/releases/probe/php/linux/$ARCHITECTURE/$PHP_VERSION" -o $PHP_VERSION)
 tar -xzf /tmp/$PHP_VERSION -C $EXTENSION_DIR/
 mv $EXTENSION_DIR/blackfire-*.so $EXTENSION_DIR/blackfire.so
 rm $EXTENSION_DIR/blackfire-*.sha


### PR DESCRIPTION
The new plugin system as of lando version 3.21 has the requirement for some changes in the plugin to work again with lando. Moreover, the installation is simplified because of the new lando "add-plugin" tooling

Thanks for any feedback,
Flo